### PR TITLE
Some improvements to Prallax

### DIFF
--- a/shaders/gbuffers_main.fsh
+++ b/shaders/gbuffers_main.fsh
@@ -65,6 +65,10 @@ vec2 getParallaxCoord(in vec2 coord, in vec3 direction) {
 
 	vec3 interval = direction * stepSize;
 	vec4 tileCoord = tileCoordinate(coord);
+	
+	// Scale up interval based on angle relative to surface
+	float angleScale = abs(normal.z);
+	interval /= angleScale;
 
 	// Start state
 	vec3  offset = vec3(0.0, 0.0, 1.0);

--- a/shaders/gbuffers_main.fsh
+++ b/shaders/gbuffers_main.fsh
@@ -61,7 +61,7 @@ vec2 getParallaxCoord(in vec2 coord, in vec3 direction) {
 	float currentHeight = texture2D(normals, coord).a;
 	if(currentHeight == 0.0) return coord;
 	
-	cvec3 stepSize = vec3(0.2, 0.2, 1.0) * 32.0 / TEXTURE_PACK_RESOLUTION;
+	cvec3 stepSize = vec3(0.2, 0.2, 1.0) / 16.0;
 
 	vec3 interval = direction * stepSize;
 	vec4 tileCoord = tileCoordinate(coord);

--- a/shaders/gbuffers_main.fsh
+++ b/shaders/gbuffers_main.fsh
@@ -67,8 +67,7 @@ vec2 getParallaxCoord(in vec2 coord, in vec3 direction) {
 	vec4 tileCoord = tileCoordinate(coord);
 	
 	// Scale up interval based on angle relative to surface
-	float angleScale = abs(normal.z);
-	interval /= angleScale;
+	interval /= abs(tbnMatrix[2].z);
 
 	// Start state
 	vec3  offset = vec3(0.0, 0.0, 1.0);


### PR DESCRIPTION
Divide stepSize by 16 instead of multiplying my 32 and then dividing by TEXTURE_PACK_RESOLUTION.
That way it should look just fine no matter what resolution your textures are.

Assuming TEXTURE_PACK_RESOLUTION == 512, this will not affect quality in any way.
Assuming TEXTURE_PACK_RESOLUTION <  512, this will improve quality significantly.
Assuming TEXTURE_PACK_RESOLUTION >  512, this will slightly decrease quality.

Comparison(TEXTURE_PACK_RESOLUTION == 16):
![Before change](https://cloud.githubusercontent.com/assets/9051920/18223131/95d45eb2-71ad-11e6-999c-5717fa921982.png)
![After change](https://cloud.githubusercontent.com/assets/9051920/18223128/7be48e5a-71ad-11e6-8961-12b1fe8cee60.png)

Scale up interval at shallow angles to improve quality a LOT, by preventing parallax from effectively disappearing at those angles.