### PR TITLE
Add dithering to reduce banding

### DIFF
--- a/shaders/final.fsh
+++ b/shaders/final.fsh
@@ -138,7 +138,7 @@ float get8x8Dither(in vec2 coord)
 
 	ivec2 patternCoord = ivec2(mod(coord.x, 8.0), mod(coord.y, 8.0));
 
-	return ditherPattern[patternCoord.y * patternCoord.x] / 65.0;
+	return ditherPattern[patternCoord.x + (patternCoord.y * 8)] / 65.0;
 }
 
 

--- a/shaders/final.fsh
+++ b/shaders/final.fsh
@@ -123,6 +123,24 @@ vec3 Uncharted2Tonemap(vec3 color) {
 	return pow(color, vec3(1.0 / 2.2));
 }
 
+float get8x8Dither(in vec2 coord)
+{
+	const float[64] ditherPattern = float[64](
+		 1, 49, 12, 61,  4, 52, 16, 64,
+		33, 17, 45, 29, 36, 20, 48, 32,
+		 9, 57,  5, 53, 12, 60,  8, 56,
+		41, 25, 37, 21, 44, 28, 40, 24,
+		 3, 51, 15, 63,  2, 50, 14, 62,
+		35, 19, 47, 31, 34, 18, 46, 30,
+		11, 59,  7, 55, 10, 58,  6, 54,
+		43, 27, 39, 23, 42, 26, 38, 22
+	);
+
+	ivec2 patternCoord = ivec2(mod(coord.x, 8.0), mod(coord.y, 8.0));
+
+	return ditherPattern[patternCoord.y * patternCoord.x] / 65.0;
+}
+
 
 void main() {
 	float depth = GetDepth(texcoord);
@@ -141,7 +159,9 @@ void main() {
 	color = Uncharted2Tonemap(color);
 	
 	color = SetSaturationLevel(color, SATURATION);
-	
+
+	color += get8x8Dither(gl_FragCoord.st) / 255.0;
+
 	gl_FragData[0] = vec4(color, 1.0);
 	
 	exit();

--- a/shaders/final.fsh
+++ b/shaders/final.fsh
@@ -23,6 +23,7 @@ varying vec2 pixelSize;
 #include "/lib/Utility.glsl"
 #include "/lib/Debug.glsl"
 #include "/lib/Fragment/Masks.fsh"
+#include "/lib/Misc/dither.glsl"
 
 vec3 GetColor(vec2 coord) {
 	return DecodeColor(texture2D(colortex3, coord).rgb);
@@ -121,24 +122,6 @@ vec3 Uncharted2Tonemap(vec3 color) {
 	color = curr * whiteScale;
 	
 	return pow(color, vec3(1.0 / 2.2));
-}
-
-float get8x8Dither(in vec2 coord)
-{
-	const float[64] ditherPattern = float[64](
-		 1, 49, 12, 61,  4, 52, 16, 64,
-		33, 17, 45, 29, 36, 20, 48, 32,
-		 9, 57,  5, 53, 12, 60,  8, 56,
-		41, 25, 37, 21, 44, 28, 40, 24,
-		 3, 51, 15, 63,  2, 50, 14, 62,
-		35, 19, 47, 31, 34, 18, 46, 30,
-		11, 59,  7, 55, 10, 58,  6, 54,
-		43, 27, 39, 23, 42, 26, 38, 22
-	);
-
-	ivec2 patternCoord = ivec2(mod(coord.x, 8.0), mod(coord.y, 8.0));
-
-	return ditherPattern[patternCoord.x + (patternCoord.y * 8)] / 65.0;
 }
 
 


### PR DESCRIPTION
This isn't as effective as it could be, due to how EncodeColor/DecodeColor work, and the precition of the buffer, but it does help.

Example of the effectiveness of dithering (here only 17 intensities per channel to make it more clear that there's dithering, rather than 256 like on most monitors, you'll need to check the full size image):
![thepowerofdithering](https://cloud.githubusercontent.com/assets/9051920/18702142/9cb60d02-7fe0-11e6-8777-8635e6903302.png)